### PR TITLE
Create ConditionStateTriggerBase<T> 

### DIFF
--- a/src/WindowsStateTriggers/CompareStateTrigger.cs
+++ b/src/WindowsStateTriggers/CompareStateTrigger.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Globalization;
-using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 
 namespace WindowsStateTriggers
@@ -19,33 +18,16 @@ namespace WindowsStateTriggers
 	/// </code>
 	/// </para>
 	/// </remarks>
-	public class CompareStateTrigger : StateTriggerBase, ITriggerValue
+	public class CompareStateTrigger : ConditionStateTriggerBase<object>
 	{
-		private void UpdateTrigger()
-		{
-			IsActive = CompareValues() == Comparison;
-		}
-
 		/// <summary>
-		/// Gets or sets the value for comparison.
+		/// Predicate that causes the trigger to activate when satisfied.
 		/// </summary>
-		public object Value
+		/// <param name="value">The value used as input to this trigger.</param>
+		/// <returns>A <see cref="bool"/> indicating whether the trigger is active.</returns>
+		protected override bool Condition(object value)
 		{
-			get { return (object)GetValue(ValueProperty); }
-			set { SetValue(ValueProperty, value); }
-		}
-
-		/// <summary>
-		/// Identifies the <see cref="Value"/> DependencyProperty
-		/// </summary>
-		public static readonly DependencyProperty ValueProperty =
-			DependencyProperty.Register("Value", typeof(object), typeof(CompareStateTrigger),
-			new PropertyMetadata(null, OnValuePropertyChanged));
-
-		private static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
-			var obj = (CompareStateTrigger)d;
-			obj.UpdateTrigger();
+			return CompareValues() == Comparison;
 		}
 
 		/// <summary>
@@ -53,7 +35,7 @@ namespace WindowsStateTriggers
 		/// </summary>
 		public object CompareTo
 		{
-			get { return (object)GetValue(CompareToProperty); }
+			get { return GetValue(CompareToProperty); }
 			set { SetValue(CompareToProperty, value); }
 		}
 
@@ -94,11 +76,11 @@ namespace WindowsStateTriggers
 				{
 					if (v1 is IComparable)
 					{
-						v2 = System.Convert.ChangeType(v2, v1.GetType(), CultureInfo.InvariantCulture);
+						v2 = Convert.ChangeType(v2, v1.GetType(), CultureInfo.InvariantCulture);
 					}
 					else if (v2 is IComparable)
 					{
-						v1 = System.Convert.ChangeType(v1, v2.GetType(), CultureInfo.InvariantCulture);
+						v1 = Convert.ChangeType(v1, v2.GetType(), CultureInfo.InvariantCulture);
 					}
 				}
 
@@ -115,36 +97,6 @@ namespace WindowsStateTriggers
 			}
 			return Comparison.NotComparable;
 		}
-
-		#region ITriggerValue
-
-		private bool m_IsActive;
-
-		/// <summary>
-		/// Gets a value indicating whether this trigger is active.
-		/// </summary>
-		/// <value><c>true</c> if this trigger is active; otherwise, <c>false</c>.</value>
-		public bool IsActive
-		{
-			get { return m_IsActive; }
-			private set
-			{
-				if (m_IsActive != value)
-				{
-					m_IsActive = value;
-					base.SetActive(value);
-					if (IsActiveChanged != null)
-						IsActiveChanged(this, EventArgs.Empty);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Occurs when the <see cref="IsActive" /> property has changed.
-		/// </summary>
-		public event EventHandler IsActiveChanged;
-
-		#endregion ITriggerValue
 	}
 	/// <summary>
 	/// Comparison types

--- a/src/WindowsStateTriggers/ConditionStateTriggerBase.cs
+++ b/src/WindowsStateTriggers/ConditionStateTriggerBase.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Morten Nielsen. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Windows.UI.Xaml;
+
+namespace WindowsStateTriggers
+{
+	/// <summary>
+	/// Base class for a trigger that takes a value of type <c>T</c> and activates depending on a condition (<c>Predicate&lt;T&gt;</c>)
+	/// </summary>
+	public abstract class ConditionStateTriggerBase<T> : StateTriggerBase, ITriggerValue
+	{
+		/// <summary>
+		/// Re-evaluates the active state of this trigger according to the current <see cref="Value"/>
+		/// </summary>
+		protected void UpdateTrigger()
+		{
+			IsActive = Condition(Value);
+		}
+
+		/// <summary>
+		/// Predicate that causes the trigger to activate when satisfied.
+		/// </summary>
+		/// <param name="value">The value used as input to this trigger.</param>
+		/// <returns>A <see cref="bool"/> indicating whether the trigger is active.</returns>
+		protected abstract bool Condition(T value);
+
+		/// <summary>
+		/// Method called when the <see cref="Value"/> changes that can be overriden by classes that inherit from <see cref="ConditionStateTriggerBase{T}"/>.
+		/// </summary>
+		/// <remarks>
+		/// The intended use of this callback is for inheritors to know when to attach event listeners as the <see cref="Value"/> changes.
+		/// </remarks>
+		protected virtual void ValueChanged() { }
+
+		/// <summary>
+		/// Constructor for <see cref="ConditionStateTriggerBase{T}"/> which initializes the activation state of the trigger.
+		/// </summary>
+		public ConditionStateTriggerBase()
+		{
+			UpdateTrigger();
+		}
+
+		/// <summary>
+		/// Gets or sets the value for comparison.
+		/// </summary>
+		public T Value
+		{
+			get { return (T)GetValue(ValueProperty); }
+			set { SetValue(ValueProperty, value); }
+		}
+
+		/// <summary>
+		/// Identifies the <see cref="Value"/> DependencyProperty
+		/// </summary>
+		public static readonly DependencyProperty ValueProperty =
+			DependencyProperty.Register("Value", typeof(T), typeof(CompareStateTrigger),
+			new PropertyMetadata(default(T), OnValuePropertyChanged));
+
+		/// <summary>
+		/// Called when the <see cref="Value"/> property changes or when another 
+		/// <see cref="DependencyProperty"/> causes the Trigger to be re-evaluated.
+		/// </summary>
+		/// <param name="d">The <see cref="DependencyObject"/> that triggered the change.</param>
+		/// <param name="e">The <see cref="DependencyPropertyChangedEventArgs"/> with the arguments relative to this change.</param>
+		protected static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			var obj = (ConditionStateTriggerBase<T>)d;
+			obj.UpdateTrigger();
+			obj.ValueChanged();
+		}
+
+		#region ITriggerValue
+
+		private bool m_IsActive;
+
+		/// <summary>
+		/// Gets a value indicating whether this trigger is active.
+		/// </summary>
+		/// <value><c>true</c> if this trigger is active; otherwise, <c>false</c>.</value>
+		public bool IsActive
+		{
+			get { return m_IsActive; }
+			private set
+			{
+				if (m_IsActive != value)
+				{
+					m_IsActive = value;
+					base.SetActive(value);
+					if (IsActiveChanged != null)
+						IsActiveChanged(this, EventArgs.Empty);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Occurs when the <see cref="IsActive" /> property has changed.
+		/// </summary>
+		public event EventHandler IsActiveChanged;
+
+		#endregion ITriggerValue
+	}
+}

--- a/src/WindowsStateTriggers/IsFalseStateTrigger.cs
+++ b/src/WindowsStateTriggers/IsFalseStateTrigger.cs
@@ -1,68 +1,21 @@
 // Copyright (c) Morten Nielsen. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Windows.Foundation.Metadata;
-using Windows.UI.Xaml;
-
 namespace WindowsStateTriggers
 {
-    /// <summary>
-    /// Enables a state if the value is false
-    /// </summary>
-    public class IsFalseStateTrigger : StateTriggerBase, ITriggerValue
+	/// <summary>
+	/// Enables a state if the value is false
+	/// </summary>
+	public class IsFalseStateTrigger : ConditionStateTriggerBase<bool>
 	{
 		/// <summary>
-		/// Gets or sets the value used to check for <c>false</c>.
+		/// Predicate that causes the trigger to activate when satisfied.
 		/// </summary>
-		public bool Value
+		/// <param name="value">The value used as input to this trigger.</param>
+		/// <returns>A <see cref="bool"/> indicating whether the trigger is active.</returns>
+		protected override bool Condition(bool value)
 		{
-			get { return (bool)GetValue(ValueProperty); }
-			set { SetValue(ValueProperty, value); }
+			return !value;
 		}
-
-		/// <summary>
-		/// Identifies the <see cref="Value"/> DependencyProperty
-		/// </summary>
-		public static readonly DependencyProperty ValueProperty =
-			DependencyProperty.Register("Value", typeof(bool), typeof(IsFalseStateTrigger), 
-			new PropertyMetadata(true, OnValuePropertyChanged));
-
-		private static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
-			var obj = (IsFalseStateTrigger)d;
-			var val = (bool)e.NewValue;
-			obj.IsActive = !val;
-		}
-
-		#region ITriggerValue
-
-		private bool m_IsActive;
-
-		/// <summary>
-		/// Gets a value indicating whether this trigger is active.
-		/// </summary>
-		/// <value><c>true</c> if this trigger is active; otherwise, <c>false</c>.</value>
-		public bool IsActive
-		{
-			get { return m_IsActive; }
-			private set
-			{
-				if (m_IsActive != value)
-				{
-					m_IsActive = value;
-					base.SetActive(value);
-					if (IsActiveChanged != null)
-						IsActiveChanged(this, EventArgs.Empty);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Occurs when the <see cref="IsActive" /> property has changed.
-		/// </summary>
-		public event EventHandler IsActiveChanged;
-
-		#endregion ITriggerValue
 	}
 }

--- a/src/WindowsStateTriggers/NotEqualStateTrigger.cs
+++ b/src/WindowsStateTriggers/NotEqualStateTrigger.cs
@@ -1,43 +1,23 @@
 // Copyright (c) Morten Nielsen. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 
 namespace WindowsStateTriggers
 {
-    /// <summary>
-    /// Enables a state if the value is not equal to another value
-    /// </summary>
-    public class NotEqualStateTrigger : StateTriggerBase
+	/// <summary>
+	/// Enables a state if the value is not equal to another value
+	/// </summary>
+	public class NotEqualStateTrigger : ConditionStateTriggerBase<object>
 	{
-		private void UpdateTrigger()
-		{
-			IsActive = !EqualsStateTrigger.AreValuesEqual(Value, NotEqualTo, true);
-		}
-
 		/// <summary>
-		/// Gets or sets the value for comparison.
+		/// Predicate that causes the trigger to activate when satisfied.
 		/// </summary>
-		public object Value
+		/// <param name="value">The value used as input to this trigger.</param>
+		/// <returns>A <see cref="bool"/> indicating whether the trigger is active.</returns>
+		protected override bool Condition(object value)
 		{
-			get { return (object)GetValue(ValueProperty); }
-			set { SetValue(ValueProperty, value); }
-		}
-
-		/// <summary>
-		/// Identifies the <see cref="Value"/> DependencyProperty
-		/// </summary>
-		public static readonly DependencyProperty ValueProperty =
-			DependencyProperty.Register("Value", typeof(object), typeof(NotEqualStateTrigger), 
-			new PropertyMetadata(null, OnValuePropertyChanged));
-
-		private static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
-			var obj = (NotEqualStateTrigger)d;
-			obj.UpdateTrigger();
+			return !EqualsStateTrigger.AreValuesEqual(Value, NotEqualTo, true);
 		}
 
 		/// <summary>
@@ -45,7 +25,7 @@ namespace WindowsStateTriggers
 		/// </summary>
 		public object NotEqualTo
 		{
-			get { return (object)GetValue(NotEqualToProperty); }
+			get { return GetValue(NotEqualToProperty); }
 			set { SetValue(NotEqualToProperty, value); }
 		}
 
@@ -54,35 +34,5 @@ namespace WindowsStateTriggers
 		/// </summary>
 		public static readonly DependencyProperty NotEqualToProperty =
 					DependencyProperty.Register("NotEqualTo", typeof(object), typeof(NotEqualStateTrigger), new PropertyMetadata(null, OnValuePropertyChanged));
-
-		#region ITriggerValue
-
-		private bool m_IsActive;
-
-		/// <summary>
-		/// Gets a value indicating whether this trigger is active.
-		/// </summary>
-		/// <value><c>true</c> if this trigger is active; otherwise, <c>false</c>.</value>
-		public bool IsActive
-		{
-			get { return m_IsActive; }
-			private set
-			{
-				if (m_IsActive != value)
-				{
-					m_IsActive = value;
-					base.SetActive(value);
-					if (IsActiveChanged != null)
-						IsActiveChanged(this, EventArgs.Empty);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Occurs when the <see cref="IsActive" /> property has changed.
-		/// </summary>
-		public event EventHandler IsActiveChanged;
-
-		#endregion ITriggerValue
 	}
 }

--- a/src/WindowsStateTriggers/RegexStateTrigger.cs
+++ b/src/WindowsStateTriggers/RegexStateTrigger.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Morten Nielsen. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using System.Text.RegularExpressions;
-using Windows.Foundation.Metadata;
 using Windows.UI.Xaml;
 
 namespace WindowsStateTriggers
@@ -20,36 +17,19 @@ namespace WindowsStateTriggers
 	/// </code>
 	/// </para>
 	/// </remarks>
-	public class RegexStateTrigger : StateTriggerBase, ITriggerValue
+	public class RegexStateTrigger : ConditionStateTriggerBase<string>
 	{
-		private void UpdateTrigger()
-		{
-			IsActive =
-					Value != null && 
-					!string.IsNullOrEmpty(Expression) &&
-                    Regex.IsMatch(Value, Expression, Options);
-		}
-
 		/// <summary>
-		/// Gets or sets the value for regex evaluation.
+		/// Predicate that causes the trigger to activate when satisfied.
 		/// </summary>
-		public string Value
+		/// <param name="value">The value used as input to this trigger.</param>
+		/// <returns>A <see cref="bool"/> indicating whether the trigger is active.</returns>
+		protected override bool Condition(string value)
 		{
-			get { return (string)GetValue(ValueProperty); }
-			set { SetValue(ValueProperty, value); }
-		}
-
-		/// <summary>
-		/// Identifies the <see cref="Value"/> DependencyProperty
-		/// </summary>
-		public static readonly DependencyProperty ValueProperty =
-			DependencyProperty.Register(nameof(Value), typeof(string), typeof(RegexStateTrigger), 
-			new PropertyMetadata(null, OnValuePropertyChanged));
-
-		private static void OnValuePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-		{
-			var obj = (RegexStateTrigger)d;
-			obj.UpdateTrigger();
+			return
+				value != null &&
+				!string.IsNullOrEmpty(Expression) &&
+				Regex.IsMatch(value, Expression, Options);
 		}
 
 		/// <summary>
@@ -81,35 +61,5 @@ namespace WindowsStateTriggers
 		/// </summary>
 		public static readonly DependencyProperty OptionsProperty =
 			DependencyProperty.Register(nameof(Options), typeof(RegexOptions), typeof(RegexStateTrigger), new PropertyMetadata(RegexOptions.None, OnValuePropertyChanged));
-		
-		#region ITriggerValue
-
-		private bool m_IsActive;
-
-		/// <summary>
-		/// Gets a value indicating whether this trigger is active.
-		/// </summary>
-		/// <value><c>true</c> if this trigger is active; otherwise, <c>false</c>.</value>
-		public bool IsActive
-		{
-			get { return m_IsActive; }
-			private set
-			{
-				if (m_IsActive != value)
-				{
-					m_IsActive = value;
-					base.SetActive(value);
-					if (IsActiveChanged != null)
-						IsActiveChanged(this, EventArgs.Empty);
-				}
-			}
-		}
-
-		/// <summary>
-		/// Occurs when the <see cref="IsActive" /> property has changed.
-		/// </summary>
-		public event EventHandler IsActiveChanged;
-
-		#endregion ITriggerValue
 	}
 }

--- a/src/WindowsStateTriggers/WindowsStateTriggers.csproj
+++ b/src/WindowsStateTriggers/WindowsStateTriggers.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="CompareStateTrigger.cs" />
     <Compile Include="CompositeStateTrigger.cs" />
+    <Compile Include="ConditionStateTriggerBase.cs" />
     <Compile Include="RegexStateTrigger.cs" />
     <Compile Include="InputTypeTrigger.cs" />
     <Compile Include="ITriggerValue.cs" />


### PR DESCRIPTION
For triggers that take a Value of type T and a Condition (Predicate<T>) that must be satisfied to activate the trigger. Fixes #24. This is for refactoring only - All triggers work as before on Test App.

What do you think? The interesting file is ConditionStateTriggerBase.cs. The only one that needed the ValueChanged callback was the IsNullOrEmptyStateTrigger.cs
