### PR TITLE
Add a nuspec and build script to create the package

### DIFF
--- a/src/WindowsStateTriggers.nuspec
+++ b/src/WindowsStateTriggers.nuspec
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>WindowsStateTriggers</id>
+        <version>1.0.0-beta1</version>
+        <title />
+        <authors>Morten Nielsen</authors>
+        <owners />
+        <licenseUrl>https://raw.githubusercontent.com/dotMorten/WindowsStateTriggers/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/dotMorten/WindowsStateTriggers</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>StateTriggers for use with the Windows 10 Visual State Manager</description>
+        <releaseNotes></releaseNotes>
+        <copyright>© Morten Nielsen 2015</copyright>
+        <language>en-US</language>
+        <tags>statetrigger adaptive uwp</tags>
+    </metadata>
+    <files>
+      
+      <file src="WindowsStateTriggers\bin\Release\WindowsStateTriggers.dll" target="lib\win81\WindowsStateTriggers.dll" />
+      <file src="WindowsStateTriggers\bin\Release\WindowsStateTriggers.pdb" target="lib\win81\WindowsStateTriggers.pdb" />
+      <file src="WindowsStateTriggers\bin\Release\WindowsStateTriggers.pri" target="lib\win81\WindowsStateTriggers.pri" />
+      <file src="WindowsStateTriggers\bin\Release\WindowsStateTriggers.xml" target="lib\win81\WindowsStateTriggers.xml" />
+        
+     
+      <!-- Source -->
+      <file src="WindowsStateTriggers\**\*.cs" target="src" exclude="_ReSharper.*\**\*.*;packages\**\*.*;**\Debug\**\*.*"/>       
+      
+    </files>
+</package>

--- a/src/WindowsStateTriggers.proj
+++ b/src/WindowsStateTriggers.proj
@@ -1,0 +1,108 @@
+﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
+
+
+  <!-- Settings -->
+
+  <PropertyGroup>
+    <SolutionName Condition="'$(SolutionName)' == ''">WindowsStateTriggers.sln</SolutionName>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <Platform Condition="'$(Platform)' == ''">x86</Platform>
+    <ParallelizeTests Condition="'$(ParallelizeTests)' == ''">true</ParallelizeTests>
+    <TrackFileAccess>false</TrackFileAccess>
+    <SolutionDir Condition="'$(SolutionDir)' == '' Or '$(SolutionDir)' == '*Undefined*'">$(MSBuildProjectDirectory)</SolutionDir>
+    <NuGetExePath Condition="'$(NuGetExePath)' == ''">$(SolutionDir)\.nuget\nuget.exe</NuGetExePath>
+    <RequestedVerbosity Condition=" '$(RequestedVerbosity)' == '' ">normal</RequestedVerbosity>
+  </PropertyGroup>
+  <ItemGroup>
+    <NuspecFiles Include="src\*.nuspec" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(PackageSources)' == '' ">
+    <PackageSource Include="https://nuget.org/api/v2/" />
+  </ItemGroup>
+
+  <!-- Build server targets -->
+
+  <Target Name="CI" DependsOnTargets="DisableParallelization;Clean;PackageRestore;Build;Packages" />
+
+  <!-- Individual targets -->
+
+  <Target Name="DisableParallelization">
+    <PropertyGroup>
+      <ParallelizeTests>false</ParallelizeTests>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="Clean">
+    <ItemGroup>
+      <CleanFileList Include="*.html;*.xml;*.nupkg;.nuget\NuGet.exe"/>
+    </ItemGroup>
+    <MSBuild
+        Projects="$(SolutionName)"
+        Targets="Clean"
+        Properties="Configuration=$(Configuration);TrackFileAccess=$(TrackFileAccess)"/>
+    <Delete Files="@(CleanFileList)"/>
+    <RemoveDir Directories="@(CleanFolderList)" ContinueOnError="true"/>
+  </Target>
+
+  <Target Name="PackageRestore" DependsOnTargets="_DownloadNuGet">
+    <Message Text="Restoring NuGet packages..." Importance="High" />    
+    <Exec Command="&quot;$(NuGetExePath)&quot; restore &quot;$(SolutionDir)\$(SolutionName)&quot; -NonInteractive -Source @(PackageSource) -Verbosity quiet" />
+  </Target>
+
+  <Target Name="Build" DependsOnTargets="PackageRestore">
+  <!--  <MSBuild
+        Projects="$(SolutionName)"
+        Targets="Build"
+        Properties="Configuration=$(Configuration);Platform=$(Platform);TrackFileAccess=$(TrackFileAccess)"/>
+
+ -->
+  </Target>
+
+  <Target Name='Packages'>
+    <Exec Command='"$(NuGetExePath)" pack %(NuspecFiles.Identity) -NoPackageAnalysis -NonInteractive -Verbosity quiet' />
+  </Target>
+
+  <Target Name="PushNuGet" DependsOnTargets="_DownloadNuGet">
+    <ItemGroup>
+      <NupkgFiles Include="*.nupkg" Exclude="*.symbols*.nupkg" />
+    </ItemGroup>
+    <Exec Command='"$(NuGetExePath)" push %(NupkgFiles.Identity) -NonInteractive' />
+  </Target>
+
+  <Target Name="_DownloadNuGet">
+    <MakeDir Directories="$(SolutionDir)\.nuget" />
+    <DownloadNuGet OutputFilename="$(NuGetExePath)" Condition="!Exists('$(NuGetExePath)')" />
+  </Target>
+
+  <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <OutputFilename ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Core" />
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Net" />
+      <Using Namespace="Microsoft.Build.Framework" />
+      <Using Namespace="Microsoft.Build.Utilities" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+          try {
+              OutputFilename = Path.GetFullPath(OutputFilename);
+
+              Log.LogMessage("Downloading latest version of NuGet.exe...");
+              WebClient webClient = new WebClient();
+              webClient.DownloadFile("https://nuget.org/nuget.exe", OutputFilename);
+
+              return true;
+          }
+          catch (Exception ex) {
+              Log.LogErrorFromException(ex);
+              return false;
+          }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+</Project>

--- a/src/WindowsStateTriggers.sln
+++ b/src/WindowsStateTriggers.sln
@@ -13,6 +13,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Markdown", "Markdown", "{62
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{385AB049-EBF3-4B9D-894C-BA16586AA3AF}"
+	ProjectSection(SolutionItems) = preProject
+		WIndowsStateTriggers.nuspec = WIndowsStateTriggers.nuspec
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,8 +64,6 @@ Global
 		{B4689B2B-C46B-40BF-A36B-D5D837352E8B}.Release|x64.Build.0 = Release|x64
 		{B4689B2B-C46B-40BF-A36B-D5D837352E8B}.Release|x64.Deploy.0 = Release|x64
 		{B4689B2B-C46B-40BF-A36B-D5D837352E8B}.Release|x86.ActiveCfg = Release|x86
-		{B4689B2B-C46B-40BF-A36B-D5D837352E8B}.Release|x86.Build.0 = Release|x86
-		{B4689B2B-C46B-40BF-A36B-D5D837352E8B}.Release|x86.Deploy.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,0 +1,39 @@
+param(
+    [string]$target = "Packages",
+    [string]$verbosity = "minimal",
+    [int]$maxCpuCount = 0
+)
+
+
+$msbuilds = @(get-command msbuild -ea SilentlyContinue)
+if ($msbuilds.Count -gt 0) {
+    $msbuild = $msbuilds[0].Definition
+}
+else {
+    if (test-path "env:\ProgramFiles(x86)") {
+        $path = join-path ${env:ProgramFiles(x86)} "MSBuild\14.0\bin\MSBuild.exe"
+        if (test-path $path) {
+            $msbuild = $path
+        }
+    }
+    if ($msbuild -eq $null) {
+        $path = join-path $env:ProgramFiles "MSBuild\14.0\bin\MSBuild.exe"
+        if (test-path $path) {
+            $msbuild = $path
+        }
+    }
+    if ($msbuild -eq $null) {
+        throw "MSBuild could not be found in the path. Please ensure MSBuild v14 (from Visual Studio 2015) is in the path."
+    }
+}
+
+if ($maxCpuCount -lt 1) {
+    $maxCpuCountText = $Env:MSBuildProcessorCount
+} else {
+    $maxCpuCountText = ":$maxCpuCount"
+}
+
+$solutionNameArg = "/property:SolutionName=WindowsStateTriggers.sln"
+
+$allArgs = @("WindowsStateTriggers.proj", "/m$maxCpuCountText", "/nologo", "/verbosity:$verbosity", "/t:$target", "/property:RequestedVerbosity=$verbosity", $solutionNameArg, $args)
+& $msbuild $allArgs


### PR DESCRIPTION
Note: command-line build doesn't fully work yet, not sure why. MSBuild direct of the sln file fails too.

So to use, build in Release in VS, then you can run the .\build.ps1 script to create the package. It will download nuget for you too, so no need to check that in.

Right now, it's set as Win81 as that's the only thing that'll work for UWP apps. 
