### PR TITLE
Fix DeviceFamily.Xbox enum value

### DIFF
--- a/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
+++ b/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
@@ -117,9 +117,9 @@ namespace WindowsStateTriggers
 		/// Windows IoT
 		/// </summary>
 		IoT = 4,
-        /// <summary>
-        /// Xbox
-        /// </summary>
-        Xbox = 4
-    }
+		/// <summary>
+		/// Xbox
+		/// </summary>
+		Xbox = 5
+	}
 }


### PR DESCRIPTION
The Xbox enum value was the same than the IoT enum value. + Fix Tab spacing.
