### PR TITLE
Continuum Support

### DIFF
--- a/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
+++ b/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using Windows.Foundation.Metadata;
+using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 
 namespace WindowsStateTriggers
@@ -11,8 +11,14 @@ namespace WindowsStateTriggers
 	/// Trigger for switching between Windows and Windows Phone
 	/// </summary>
 	public class DeviceFamilyStateTrigger : StateTriggerBase, ITriggerValue
-	{
-		private static string deviceFamily;
+    {
+        private const string Desktop = "Windows.Desktop";
+        private const string Mobile = "Windows.Mobile";
+        private const string Team = "Windows.Team";
+        private const string Iot = "Windows.IoT";
+        private const string Xbox = "Windows.Xbox";
+
+        private static string deviceFamily;
 
 		static DeviceFamilyStateTrigger()
 		{
@@ -43,19 +49,34 @@ namespace WindowsStateTriggers
 			DependencyProperty.Register("DeviceFamily", typeof(DeviceFamily), typeof(DeviceFamilyStateTrigger),
 			new PropertyMetadata(DeviceFamily.Unknown, OnDeviceTypePropertyChanged));
 
-		private static void OnDeviceTypePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        private static void OnDeviceTypePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
 			var obj = (DeviceFamilyStateTrigger)d;
 			var val = (DeviceFamily)e.NewValue;
-			if (deviceFamily == "Windows.Mobile")
+
+		    if (deviceFamily == Mobile)
+		    {
+                // This is where we check for continuum, because if the device family is mobile,
+                // but screensize is greater than 6", then it means we are in continuum as the largest
+                // screensize for a mobile device is 6"
+                // If this is the case, then we want to force the device family to think it's the 
+                // desktop so that UIs based on desktop get shown.
+		        var size = DisplayInformation.GetForCurrentView().DiagonalSizeInInches;
+		        if (size.HasValue && size.Value > 6)
+		        {
+		            deviceFamily = Desktop;
+		        }
+		    }
+
+			if (deviceFamily == Mobile)
 				obj.IsActive = (val == DeviceFamily.Mobile);
-			else if (deviceFamily == "Windows.Desktop")
+			else if (deviceFamily == Desktop)
 				obj.IsActive = (val == DeviceFamily.Desktop);
-			else if (deviceFamily == "Windows.Team")
+			else if (deviceFamily == Team)
 				obj.IsActive = (val == DeviceFamily.Team);
-			else if (deviceFamily == "Windows.IoT")
+			else if (deviceFamily == Iot)
 				obj.IsActive = (val == DeviceFamily.IoT);
-            else if (deviceFamily == "Windows.Xbox")
+            else if (deviceFamily == Xbox)
                 obj.IsActive = (val == DeviceFamily.Xbox);
             else
                 obj.IsActive = (val == DeviceFamily.Unknown);

--- a/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
+++ b/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
 using Windows.UI.Xaml;
 
@@ -77,15 +78,18 @@ namespace WindowsStateTriggers
 	    {
 	        if (deviceFamily == Mobile)
 	        {
-	            // This is where we check for continuum, because if the device family is mobile,
-	            // but screensize is greater than 6", then it means we are in continuum as the largest
-	            // screensize for a mobile device is 6"
-	            // If this is the case, then we want to force the device family to think it's the 
-	            // desktop so that UIs based on desktop get shown.
-	            var size = DisplayInformation.GetForCurrentView().DiagonalSizeInInches;
-	            if (size.HasValue && size.Value > MaximumScreenSizeForMobile)
+	            if (ApiInformation.IsPropertyPresent("DisplayInformation", "DiagonalSizeInInches"))
 	            {
-	                deviceFamily = Desktop;
+	                // This is where we check for continuum, because if the device family is mobile,
+	                // but screensize is greater than 6", then it means we are in continuum as the largest
+	                // screensize for a mobile device is 6"
+	                // If this is the case, then we want to force the device family to think it's the 
+	                // desktop so that UIs based on desktop get shown.
+	                var size = DisplayInformation.GetForCurrentView().DiagonalSizeInInches;
+	                if (size.HasValue && size.Value > MaximumScreenSizeForMobile)
+	                {
+	                    deviceFamily = Desktop;
+	                }
 	            }
 	        }
 

--- a/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
+++ b/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
@@ -78,7 +78,7 @@ namespace WindowsStateTriggers
 	    {
 	        if (deviceFamily == Mobile)
 	        {
-	            if (ApiInformation.IsPropertyPresent("DisplayInformation", "DiagonalSizeInInches"))
+	            if (ApiInformation.IsPropertyPresent(nameof(DisplayInformation), "DiagonalSizeInInches"))
 	            {
 	                // This is where we check for continuum, because if the device family is mobile,
 	                // but screensize is greater than 6", then it means we are in continuum as the largest

--- a/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
+++ b/src/WindowsStateTriggers/DeviceFamilyStateTrigger.cs
@@ -47,42 +47,63 @@ namespace WindowsStateTriggers
 		/// </summary>
 		public static readonly DependencyProperty DeviceFamilyProperty =
 			DependencyProperty.Register("DeviceFamily", typeof(DeviceFamily), typeof(DeviceFamilyStateTrigger),
-			new PropertyMetadata(DeviceFamily.Unknown, OnDeviceTypePropertyChanged));
+			new PropertyMetadata(DeviceFamily.Unknown, OnPropertyChanged));
 
-        private static void OnDeviceTypePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        /// <summary>
+        /// The maximum screen size for mobile property
+        /// </summary>
+        public static readonly DependencyProperty MaximumScreenSizeForMobileProperty = DependencyProperty.Register(
+	        "MaximumScreenSizeForMobile", typeof (double), typeof (DeviceFamilyStateTrigger), new PropertyMetadata(6d, OnPropertyChanged));
+
+        /// <summary>
+        /// Gets or sets the maximum screen size for mobile. This is used for checking if in Continuum
+        /// </summary>
+        /// <value>
+        /// The maximum screen size for mobile.
+        /// </value>
+        public double MaximumScreenSizeForMobile
+	    {
+	        get { return (double) GetValue(MaximumScreenSizeForMobileProperty); }
+	        set { SetValue(MaximumScreenSizeForMobileProperty, value); }
+	    }
+
+        private static void OnPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
 		{
 			var obj = (DeviceFamilyStateTrigger)d;
-			var val = (DeviceFamily)e.NewValue;
-
-		    if (deviceFamily == Mobile)
-		    {
-                // This is where we check for continuum, because if the device family is mobile,
-                // but screensize is greater than 6", then it means we are in continuum as the largest
-                // screensize for a mobile device is 6"
-                // If this is the case, then we want to force the device family to think it's the 
-                // desktop so that UIs based on desktop get shown.
-		        var size = DisplayInformation.GetForCurrentView().DiagonalSizeInInches;
-		        if (size.HasValue && size.Value > 6)
-		        {
-		            deviceFamily = Desktop;
-		        }
-		    }
-
-			if (deviceFamily == Mobile)
-				obj.IsActive = (val == DeviceFamily.Mobile);
-			else if (deviceFamily == Desktop)
-				obj.IsActive = (val == DeviceFamily.Desktop);
-			else if (deviceFamily == Team)
-				obj.IsActive = (val == DeviceFamily.Team);
-			else if (deviceFamily == Iot)
-				obj.IsActive = (val == DeviceFamily.IoT);
-            else if (deviceFamily == Xbox)
-                obj.IsActive = (val == DeviceFamily.Xbox);
-            else
-                obj.IsActive = (val == DeviceFamily.Unknown);
+		    obj.UpdateTrigger();
 		}
 
-		#region ITriggerValue
+	    private void UpdateTrigger()
+	    {
+	        if (deviceFamily == Mobile)
+	        {
+	            // This is where we check for continuum, because if the device family is mobile,
+	            // but screensize is greater than 6", then it means we are in continuum as the largest
+	            // screensize for a mobile device is 6"
+	            // If this is the case, then we want to force the device family to think it's the 
+	            // desktop so that UIs based on desktop get shown.
+	            var size = DisplayInformation.GetForCurrentView().DiagonalSizeInInches;
+	            if (size.HasValue && size.Value > MaximumScreenSizeForMobile)
+	            {
+	                deviceFamily = Desktop;
+	            }
+	        }
+
+	        if (deviceFamily == Mobile)
+	            IsActive = (DeviceFamily == DeviceFamily.Mobile);
+	        else if (deviceFamily == Desktop)
+	            IsActive = (DeviceFamily == DeviceFamily.Desktop);
+	        else if (deviceFamily == Team)
+	            IsActive = (DeviceFamily == DeviceFamily.Team);
+	        else if (deviceFamily == Iot)
+	            IsActive = (DeviceFamily == DeviceFamily.IoT);
+	        else if (deviceFamily == Xbox)
+	            IsActive = (DeviceFamily == DeviceFamily.Xbox);
+	        else
+	            IsActive = (DeviceFamily == DeviceFamily.Unknown);
+	    }
+
+	    #region ITriggerValue
 
 		private bool m_IsActive;
 

--- a/src/WindowsStateTriggers/WindowsStateTriggers.csproj
+++ b/src/WindowsStateTriggers/WindowsStateTriggers.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>WindowsStateTriggers</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10240.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.10563.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Updated the DeviceFamilyStateTrigger to support continuum.

Note: This change bumps the target SDK required to be 10563 as it requires a new API (DiagonalSizeInInches). If it's run on anything less than that, it should still behave as it used to as there are API checks in place.
