### PR TITLE
Make it possible for EqualsStateTrigger (and NotEqualStateTrigger) to handle enums.

### DIFF
--- a/src/WindowsStateTriggers/EqualsStateTrigger.cs
+++ b/src/WindowsStateTriggers/EqualsStateTrigger.cs
@@ -70,33 +70,33 @@ namespace WindowsStateTriggers
 			{
 				return true;
 			}
-			if (value1 != null && value2 != null)
+			if (value1 != null && value2 != null && value1.GetType() != value2.GetType() && convertType)
 			{
-				//Let's see if we can convert - for perf reasons though, try and use the right type in and out
-				if (value1.GetType() != value2.GetType() && convertType)
+				if (ConvertTypeEquals(value1, value2))
 				{
-					if (value2 is Enum)
-					{
-						value1 = Enum.ToObject(value2.GetType(), value1);
-					}
-					var t2 = Convert.ChangeType(value1, value2.GetType(), CultureInfo.InvariantCulture);
-					if (value2.Equals(t2))
-					{
-						return true;
-					}
-					//try the other way around
-					if (value1 is Enum)
-					{
-						value2 = Enum.ToObject(value1.GetType(), value2);
-					}
-					t2 = Convert.ChangeType(value2, value1.GetType(), CultureInfo.InvariantCulture);
-					if (value1.Equals(t2))
-					{
-						return true;
-					}
+					return true;
+				}
+				// Try the other way around:
+				if (ConvertTypeEquals(value2, value1))
+				{
+					return true;
 				}
 			}
 			return false;
+		}
+
+		private static bool ConvertTypeEquals(object value1, object value2)
+		{
+			// Let's see if we can convert:
+			if (value2 is Enum)
+			{
+				value1 = Enum.ToObject(value2.GetType(), value1);
+			}
+			else
+			{
+				value1 = Convert.ChangeType(value1, value2.GetType(), CultureInfo.InvariantCulture);
+			}
+			return value2.Equals(value1);
 		}
 
 		#region ITriggerValue

--- a/src/WindowsStateTriggers/EqualsStateTrigger.cs
+++ b/src/WindowsStateTriggers/EqualsStateTrigger.cs
@@ -70,7 +70,7 @@ namespace WindowsStateTriggers
 			{
 				return true;
 			}
-			if (value1 != null && value2 != null && value1.GetType() != value2.GetType() && convertType)
+			if (value1 != null && value2 != null && convertType)
 			{
 				if (ConvertTypeEquals(value1, value2))
 				{

--- a/src/WindowsStateTriggers/EqualsStateTrigger.cs
+++ b/src/WindowsStateTriggers/EqualsStateTrigger.cs
@@ -90,6 +90,10 @@ namespace WindowsStateTriggers
 			// Let's see if we can convert:
 			if (value2 is Enum)
 			{
+                // Don't let Enum.ToObject() throw an exception:
+			    if (!(value1 is int) && !(value1 is Enum))
+			        return false;
+
 				value1 = Enum.ToObject(value2.GetType(), value1);
 			}
 			else

--- a/src/WindowsStateTriggers/EqualsStateTrigger.cs
+++ b/src/WindowsStateTriggers/EqualsStateTrigger.cs
@@ -83,17 +83,25 @@ namespace WindowsStateTriggers
 			// Let's see if we can convert:
 			if (value2 is Enum)
 			{
-				// Don't let Enum.ToObject() throw an exception:
-				if (!(value1 is int) && !(value1 is Enum))
-					return false;
-
-				value1 = Enum.ToObject(value2.GetType(), value1);
+				value1 = ConvertToEnum(value2.GetType(), value1);
 			}
 			else
 			{
 				value1 = Convert.ChangeType(value1, value2.GetType(), CultureInfo.InvariantCulture);
 			}
 			return value2.Equals(value1);
+		}
+
+		private static object ConvertToEnum(Type enumType, object value)
+		{
+			try
+			{
+				return Enum.IsDefined(enumType, value) ? Enum.ToObject(enumType, value) : null;
+			}
+			catch
+			{
+				return null;
+			}
 		}
 
 		#region ITriggerValue

--- a/src/WindowsStateTriggers/EqualsStateTrigger.cs
+++ b/src/WindowsStateTriggers/EqualsStateTrigger.cs
@@ -72,15 +72,8 @@ namespace WindowsStateTriggers
 			}
 			if (value1 != null && value2 != null && convertType)
 			{
-				if (ConvertTypeEquals(value1, value2))
-				{
-					return true;
-				}
-				// Try the other way around:
-				if (ConvertTypeEquals(value2, value1))
-				{
-					return true;
-				}
+				// Try the conversion in both ways:
+				return ConvertTypeEquals(value1, value2) || ConvertTypeEquals(value2, value1);
 			}
 			return false;
 		}
@@ -90,9 +83,9 @@ namespace WindowsStateTriggers
 			// Let's see if we can convert:
 			if (value2 is Enum)
 			{
-                // Don't let Enum.ToObject() throw an exception:
-			    if (!(value1 is int) && !(value1 is Enum))
-			        return false;
+				// Don't let Enum.ToObject() throw an exception:
+				if (!(value1 is int) && !(value1 is Enum))
+					return false;
 
 				value1 = Enum.ToObject(value2.GetType(), value1);
 			}

--- a/src/WindowsStateTriggers/EqualsStateTrigger.cs
+++ b/src/WindowsStateTriggers/EqualsStateTrigger.cs
@@ -75,13 +75,21 @@ namespace WindowsStateTriggers
 				//Let's see if we can convert - for perf reasons though, try and use the right type in and out
 				if (value1.GetType() != value2.GetType() && convertType)
 				{
-					var t2 = System.Convert.ChangeType(value1, value2.GetType(), CultureInfo.InvariantCulture);
+					if (value2 is Enum)
+					{
+						value1 = Enum.ToObject(value2.GetType(), value1);
+					}
+					var t2 = Convert.ChangeType(value1, value2.GetType(), CultureInfo.InvariantCulture);
 					if (value2.Equals(t2))
 					{
 						return true;
 					}
 					//try the other way around
-					t2 = System.Convert.ChangeType(value2, value1.GetType(), CultureInfo.InvariantCulture);
+					if (value1 is Enum)
+					{
+						value2 = Enum.ToObject(value1.GetType(), value2);
+					}
+					t2 = Convert.ChangeType(value2, value1.GetType(), CultureInfo.InvariantCulture);
 					if (value1.Equals(t2))
 					{
 						return true;


### PR DESCRIPTION
The title sums it up.
The problem at the moment is that if you try to bind/define the Value and EqualTo values to enums for example like this:

``` xaml
<local:EqualsStateTrigger Value="{x:Bind Day.State, Mode=OneWay}">
    <local:EqualsStateTrigger.EqualTo>
        <viewModel:DayState>None</viewModel:DayState>
    </local:EqualsStateTrigger.EqualTo>
</local:EqualsStateTrigger>
```

(This syntax is needed since there is no x:Static in UWP: http://stackoverflow.com/questions/31963913/xstatic-in-uwp-xaml),
where DayState is an enum:

``` c#
enum DayState
{
    None,
    Alarmed
}
```

you'll get this exception thanks to the Convert.ChangeType() calls in AreValuesEqual():
**Additional information: Invalid cast from 'System.Int32' to 'ViewModel.DayState'.**
Since the type of EqualsTo's value will be int at this point. It doesn't matter that we declared it as an enum in our XAML.

To solve this, we have to check if the conversionType is an enum. If so, we convert the value  to an object using conversionType with Enum.ToObject(). After that, we can safely use ChangeType().

One big caveat of this workaround is that you can compare different types of enums this way and it will work without trouble if the two types have the same number of members.
